### PR TITLE
Implemented changes per #8

### DIFF
--- a/blockkit/objects.py
+++ b/blockkit/objects.py
@@ -56,9 +56,10 @@ class Option(Component):
     text = TextField(max_length=75, plain=True)
     value = StringField(max_length=75)
     url = UrlField(max_length=3000)
+    description = TextField(max_length=75, plain=True)
 
-    def __init__(self, text, value, url=None):
-        super().__init__(text, value, url)
+    def __init__(self, text, value, url=None, description=None):
+        super().__init__(text, value, url, description)
 
 
 class OptionGroup(Component):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -44,14 +44,14 @@ def test_builds_confirm(plain_text, markdown_text, values):
 
 
 def test_builds_option(plain_text, values):
-    option = Option(plain_text, values.value, values.url)
+    option = Option(plain_text, values.value, values.url, plain_text)
 
     assert option.build() == {
         "text": {"type": Text.plain, "text": values.text},
         "value": values.value,
         "url": values.url,
+        "description": {"type": Text.plain, "text": values.text}
     }
-
 
 def test_builds_option_group(plain_text, option, values):
     option_group = OptionGroup(plain_text, [option for _ in range(3)])


### PR DESCRIPTION
Hey, so it seems to be what it takes to add `description` field to `Option` object per #8.

I've added the keyword argument as the last one to `Option` so it won't break existing code that uses the library if all 3 fields are passed as arguments.

Additionally, I've tested that adding `description` field does not break SBK when `Option` object is used in other scenarios, such as as an item in Overflow menus etc. See [SBK builder example in Overflow](https://api.slack.com/tools/block-kit-builder?mode=message&blocks=%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22This%20block%20has%20an%20overflow%20menu.%22%7D%2C%22accessory%22%3A%7B%22type%22%3A%22overflow%22%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22text%22%3A%22The%20way%20to%20get%20started%20is%20to%20quit%20_talking_%20and%20begin%20*doing*%22%2C%22type%22%3A%22plain_text%22%7D%2C%22value%22%3A%22value%22%2C%22url%22%3A%22https%3A%2F%2Fexample.com%22%2C%22description%22%3A%7B%22text%22%3A%22The%20way%20to%20get%20started%20is%20to%20quit%20_talking_%20and%20begin%20*doing*%22%2C%22type%22%3A%22plain_text%22%7D%7D%5D%7D%7D%5D) and [SBK builder example in Radio buttons](https://api.slack.com/tools/block-kit-builder?mode=modal&view=%7B%22type%22%3A%22modal%22%2C%22title%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22My%20App%22%2C%22emoji%22%3Atrue%7D%2C%22submit%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Submit%22%2C%22emoji%22%3Atrue%7D%2C%22close%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Cancel%22%2C%22emoji%22%3Atrue%7D%2C%22blocks%22%3A%5B%7B%22type%22%3A%22section%22%2C%22text%22%3A%7B%22type%22%3A%22mrkdwn%22%2C%22text%22%3A%22*Choose%20which%20members%20will%20receive%20an%20alert%20in%20direct%20messages*%22%7D%2C%22accessory%22%3A%7B%22type%22%3A%22radio_buttons%22%2C%22initial_option%22%3A%7B%22text%22%3A%7B%22text%22%3A%22The%20way%20to%20get%20started%20is%20to%20quit%20_talking_%20and%20begin%20*doing*%22%2C%22type%22%3A%22plain_text%22%7D%2C%22value%22%3A%22value%22%2C%22description%22%3A%7B%22text%22%3A%22The%20way%20to%20get%20started%20is%20to%20quit%20_talking_%20and%20begin%20*doing*%22%2C%22type%22%3A%22plain_text%22%7D%7D%2C%22options%22%3A%5B%7B%22text%22%3A%7B%22text%22%3A%22The%20way%20to%20get%20started%20is%20to%20quit%20_talking_%20and%20begin%20*doing*%22%2C%22type%22%3A%22plain_text%22%7D%2C%22value%22%3A%22value%22%2C%22description%22%3A%7B%22text%22%3A%22The%20way%20to%20get%20started%20is%20to%20quit%20_talking_%20and%20begin%20*doing*%22%2C%22type%22%3A%22plain_text%22%7D%7D%2C%7B%22text%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Option%202%22%7D%2C%22value%22%3A%22option%202%22%2C%22description%22%3A%7B%22type%22%3A%22plain_text%22%2C%22text%22%3A%22Option%202%22%7D%7D%5D%7D%7D%5D%7D).

Do let me know if any issues! Would be very grateful if you merged the PR and updated the library on PyPi so I can avoid doing horrible hax to get it working with an existing version of the library.

